### PR TITLE
Add support for moduleIds option

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,19 @@ defaults to false. Whether to process JsAssetFiles (.js) too. *By default to Pro
 grails.asset.babel.options = [blacklist: ['useStrict'], loose: 'all'] // babel transfom options. see https://babeljs.io/docs/usage/options/ for more information
 ```
 defaults to null. A Map of options passed to babels transform method. see https://babeljs.io/docs/usage/options/ for possible values
+
+## Modules
+```
+grails.asset.babel.options = [modules: 'amd', moduleIds: true]
+```
+When the `moduleIds` option is set the plugin provides Babel with a `moduleId` for each file. The ID is the relative path of the file inside `grails-app/assets/javascripts` with the file extension removed. 
+
+```
+e.g.
+# File Path:
+grails-app/assets/javascripts/foo/bar.js
+# Generated moduleId:
+foo/bar
+```
+
+Note: Explicit module IDs are not available when generating CommonJS modules.

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'maven-publish'
 apply plugin: 'maven'
 
 group = 'net.errbuddy.plugins'
-version = '1.3.0'
+version = '1.4.0'
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
 buildscript {
@@ -36,7 +36,7 @@ sourceSets {
 dependencies {
     provided 'org.codehaus.groovy:groovy-all:2.0.7'
     compile 'ch.qos.logback:logback-classic:1.1.3'
-    compile 'com.bertramlabs.plugins:asset-pipeline-core:2.3.0'
+    compile 'com.bertramlabs.plugins:asset-pipeline-core:2.6.2'
     compile 'org.mozilla:rhino:1.7R4'
     compile 'com.google.code.gson:gson:2.3.1'
     testCompile 'org.spockframework:spock-core:0.7-groovy-2.0'

--- a/src/main/groovy/asset/pipeline/babel/BabelProcessor.groovy
+++ b/src/main/groovy/asset/pipeline/babel/BabelProcessor.groovy
@@ -91,7 +91,7 @@ class BabelProcessor extends AbstractProcessor {
     }
 
     static boolean isEnabled(){
-        config?.enabled != null ? config.enabled as Boolean : true
+        config?.containsKey('enabled') ? config.enabled as Boolean : true
     }
 
     static boolean isProcessJsFiles(){

--- a/src/test/groovy/asset/pipeline/babel/BabelProcessorSpec.groovy
+++ b/src/test/groovy/asset/pipeline/babel/BabelProcessorSpec.groovy
@@ -140,4 +140,27 @@ try {
         false     | false
 
     }
+
+	@Unroll
+	def "Test that module IDs are generated correctly #path => #expected"() {
+		given:
+		BabelProcessor processor = new BabelProcessor(new AssetCompiler())
+		when:
+		def moduleId = processor.removeExtensionFromPath(path)
+
+		then:
+		moduleId == expected
+
+		where:
+		path             | expected
+		'a/b/c'         | 'a/b/c'
+		'a/b/c.jpg'     | 'a/b/c'
+		'a/b/c.jpg.jpg' | 'a/b/c.jpg'
+		'a.b/c'         | 'a.b/c'
+		'a.b/c.jpg'     | 'a.b/c'
+		'a.b/c.jpg.jpg' | 'a.b/c.jpg'
+		'c'             | 'c'
+		'c.jpg'         | 'c'
+		'c.jpg.jpg'     | 'c.jpg'
+	}
 }


### PR DESCRIPTION
Babel was always returning "unknown" when the `moduleIds` option was set, this provides the module ID explicitly based on the asset pipeline path.

ex.
File Path: `grails-app/assets/javascripts/foo/bar.js`
ModuleId: `foo/bar`

Also:
- upgrade to asset-pipeline-core:2.6.2
- bump version to 1.4.0.
