### PR TITLE
Don't export dependency on logging implementation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,11 +35,12 @@ sourceSets {
 
 dependencies {
     provided 'org.codehaus.groovy:groovy-all:2.0.7'
-    compile 'ch.qos.logback:logback-classic:1.1.3'
+    compile 'org.slf4j:slf4j-api:1.7.7'
     compile 'com.bertramlabs.plugins:asset-pipeline-core:2.6.9'
     compile 'org.mozilla:rhino:1.7R4'
     compile 'com.google.code.gson:gson:2.3.1'
     testCompile 'org.spockframework:spock-core:0.7-groovy-2.0'
+    testCompile 'ch.qos.logback:logback-classic:1.1.3'
 }
 
 apply plugin: 'com.jfrog.bintray'


### PR DESCRIPTION
Exporting the logging implementation (logback-classic) can cause multiple SLF4J bindings to appear in the classpath of upstream applications. Only the SLF4J API dependency is needed for compilation.
