### PR TITLE
Give babel asset filenames, allows sourceMaps.

### DIFF
--- a/src/main/groovy/asset/pipeline/babel/BabelProcessor.groovy
+++ b/src/main/groovy/asset/pipeline/babel/BabelProcessor.groovy
@@ -58,6 +58,8 @@ class BabelProcessor extends AbstractProcessor {
             try {
                 String localBabelOptions = globalBabelOptions
                 Map config = configuration?.options ? configuration.options.clone() as HashMap : [:]
+                config.filename = assetFile.name
+
                 if (config?.moduleIds) {
                     // Used when transpiling ES2015 modules to other formats,
                     // provides babel with a module ID based on the assetFile's location.

--- a/src/main/groovy/asset/pipeline/babel/BabelProcessor.groovy
+++ b/src/main/groovy/asset/pipeline/babel/BabelProcessor.groovy
@@ -15,7 +15,6 @@ class BabelProcessor extends AbstractProcessor {
 
     static Scriptable globalScope
 
-    String globalBabelOptions
 
     public static final ThreadLocal THREAD_LOCAL = new ThreadLocal()
     private static final CONVERTER = new Gson()
@@ -23,11 +22,6 @@ class BabelProcessor extends AbstractProcessor {
 
     BabelProcessor(AssetCompiler precompiler) {
         super(precompiler)
-        if (configuration) {
-            globalBabelOptions = CONVERTER.toJson(configuration.options ?: [:])
-        } else {
-            globalBabelOptions = "{}" //
-        }
         // only load all the javascript if it is enabled AND not yet initialized
         if (enabled && !contextInitialized) {
             ClassLoader classLoader = this.class.classLoader
@@ -56,7 +50,6 @@ class BabelProcessor extends AbstractProcessor {
         // the given AssetFile is a Es6File OR JsxFile OR processJsFiles is enabled
         if (enabled && (processJsFiles || assetFile in Es6AssetFile || assetFile in JsxAssetFile)) {
             try {
-                String localBabelOptions = globalBabelOptions
                 Map config = configuration?.options ? configuration.options.clone() as HashMap : [:]
                 config.filename = assetFile.name
 
@@ -64,8 +57,9 @@ class BabelProcessor extends AbstractProcessor {
                     // Used when transpiling ES2015 modules to other formats,
                     // provides babel with a module ID based on the assetFile's location.
                     config.moduleId = removeExtensionFromPath(assetFile.path)
-                    localBabelOptions = CONVERTER.toJson(config ?: [:])
                 }
+                String localBabelOptions = CONVERTER.toJson(config ?: [:])
+
                 Context cx = Context.enter()
                 THREAD_LOCAL.set(assetFile)
                 def compileScope = cx.newObject(globalScope)
@@ -92,11 +86,11 @@ class BabelProcessor extends AbstractProcessor {
         AssetPipelineConfigHolder.config?.babel
     }
 
-    static boolean isEnabled(){
+    static boolean isEnabled() {
         configuration?.containsKey('enabled') ? configuration.enabled as Boolean : true
     }
 
-    static boolean isProcessJsFiles(){
+    static boolean isProcessJsFiles() {
         configuration?.processJsFiles != null ? configuration.processJsFiles as Boolean : false
     }
 


### PR DESCRIPTION
Tried enabling source maps, ran into this

```
{
  "version": 3,
  "sources": ["unknown"],
  "names": [],
  ....
}
```

Chrome and Firefox didn't like the `unknown` source. Giving Babel the filename to generate sourceMaps with works for inline maps:

```
{
  "version":3,
  "sources": ["foo.js"],
  "names": [],
  ...
}
```
